### PR TITLE
Use underscores in the library name consistently.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Sendgrid account is fast. Sendgrid's REST API is somewhat more
 complicated than the one provided by Mailgun. Both services have a
 free tier and aren't terribly expensive for small volumes of mail.
 
-To use Sendgrid with `tidy-email`, you will need:
+To use Sendgrid with `tidy_email`, you will need:
 
 1. An API key. You'll need to create this in the console and set the
    permissions accordingly.
@@ -117,7 +117,7 @@ you will need to obtain the hostname, username, and password for the
 server. Many email services support SMTP in addition to a REST API
 (take, for example [Amazon
 SES](https://docs.aws.amazon.com/ses/latest/dg/smtp-credentials.html)),
-so this is a useful option if you want to use `tidy-email` with a
+so this is a useful option if you want to use `tidy_email` with a
 service that isn't supported by name yet.
 
 ## Examples
@@ -164,7 +164,7 @@ suggestions about how to do this.
 ## Contact
 
 The best place to record feature requests and bugs is in the
-[issues](https://github.com/jsthomas/tidy-email/issues) section of
+[issues](https://github.com/jsthomas/tidy_email/issues) section of
 this repo.
 
 I am also available on Discord and Discuss:

--- a/dune-project
+++ b/dune-project
@@ -3,7 +3,7 @@
 
 (generate_opam_files true)
 
-(source (github jsthomas/tidy-email))
+(source (github jsthomas/tidy_email))
 (license MIT)
 (authors "Joe Thomas")
 (maintainers "jsthomas@protonmail.com")
@@ -12,7 +12,7 @@
  (name tidy_email)
  (synopsis "An OCaml library that simplifies connecting to email services")
  (description "\
-Tidy-email provides a consistent interface for sending email.
+tidy_email provides a consistent interface for sending email.
 It defines types for sending messages via serveral different
 backend services (SMTP, Mailgun, etc.). Also included is a simple
 backend suitable for testing that captures messages without

--- a/mailgun/example/send.ml
+++ b/mailgun/example/send.ml
@@ -20,7 +20,7 @@ let send use_html sender recipient =
       api_key = Sys.getenv "MAILGUN_API_KEY";
       base_url = Sys.getenv "MAILGUN_BASE_URL";
     } in
-  let subject = "Test message from tidy-email via Mailgun." in
+  let subject = "Test message from tidy_email via Mailgun." in
   let body = if use_html then html_body else text_body in
   let email = Email.make ~sender ~recipient ~subject ~body in
   Printf.printf "Starting email send.\n";

--- a/sendgrid/example/send.ml
+++ b/sendgrid/example/send.ml
@@ -21,7 +21,7 @@ let send use_html sender recipient =
       api_key = Sys.getenv "SENDGRID_API_KEY";
       base_url = Sys.getenv "SENDGRID_BASE_URL";
     } in
-  let subject = "A test text email from tidy-email via Sendgrid." in
+  let subject = "A test text email from tidy_email via Sendgrid." in
   let body = if use_html then html_body else text_body in
   let email = Email.make ~sender ~recipient ~subject ~body in
   Printf.printf "Starting email send.\n";

--- a/smtp/example/send.ml
+++ b/smtp/example/send.ml
@@ -24,7 +24,7 @@ let send use_html sender recipient =
   let body = if use_html then html_body else text_body in
   let email =
     Email.make ~sender ~recipient
-      ~subject:"Test message from tidy-email via SMTP" ~body in
+      ~subject:"Test message from tidy_email via SMTP" ~body in
   Printf.printf "Starting email send.\n";
   let%lwt result = Smtp.send config email in
   let _ =

--- a/tidy_email.opam
+++ b/tidy_email.opam
@@ -3,7 +3,7 @@ opam-version: "2.0"
 version: "0.0.1"
 synopsis: "An OCaml library that simplifies connecting to email services"
 description: """
-Tidy-email provides a consistent interface for sending email.
+tidy_email provides a consistent interface for sending email.
 It defines types for sending messages via serveral different
 backend services (SMTP, Mailgun, etc.). Also included is a simple
 backend suitable for testing that captures messages without
@@ -12,8 +12,8 @@ sending them.
 maintainer: ["jsthomas@protonmail.com"]
 authors: ["Joe Thomas"]
 license: "MIT"
-homepage: "https://github.com/jsthomas/tidy-email"
-bug-reports: "https://github.com/jsthomas/tidy-email/issues"
+homepage: "https://github.com/jsthomas/tidy_email"
+bug-reports: "https://github.com/jsthomas/tidy_email/issues"
 depends: [
   "bisect_ppx" {dev & >= "2.5.0"}
   "dune" {>= "2.8" & >= "2.0"}
@@ -35,4 +35,4 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/jsthomas/tidy-email.git"
+dev-repo: "git+https://github.com/jsthomas/tidy_email.git"

--- a/tidy_email/src/list_backend.mli
+++ b/tidy_email/src/list_backend.mli
@@ -1,4 +1,4 @@
-(** Clients of tidy-email may want a mock email backend suitable for
+(** Clients of tidy_email may want a mock email backend suitable for
    unit tests.  The backend described in this module accumulates
    messages in a list for later analysis.  *)
 

--- a/tidy_email_mailgun.opam
+++ b/tidy_email_mailgun.opam
@@ -6,8 +6,8 @@ description: ""
 maintainer: ["jsthomas@protonmail.com"]
 authors: ["Joe Thomas"]
 license: "MIT"
-homepage: "https://github.com/jsthomas/tidy-email"
-bug-reports: "https://github.com/jsthomas/tidy-email/issues"
+homepage: "https://github.com/jsthomas/tidy_email"
+bug-reports: "https://github.com/jsthomas/tidy_email/issues"
 depends: [
   "bisect_ppx" {dev & >= "2.5.0"}
   "alcotest-lwt" {dev & >= "1.4.0"}
@@ -34,4 +34,4 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/jsthomas/tidy-email.git"
+dev-repo: "git+https://github.com/jsthomas/tidy_email.git"

--- a/tidy_email_sendgrid.opam
+++ b/tidy_email_sendgrid.opam
@@ -7,8 +7,8 @@ description: ""
 maintainer: ["jsthomas@protonmail.com"]
 authors: ["Joe Thomas"]
 license: "MIT"
-homepage: "https://github.com/jsthomas/tidy-email"
-bug-reports: "https://github.com/jsthomas/tidy-email/issues"
+homepage: "https://github.com/jsthomas/tidy_email"
+bug-reports: "https://github.com/jsthomas/tidy_email/issues"
 depends: [
   "bisect_ppx" {dev & >= "2.5.0"}
   "alcotest-lwt" {dev & >= "1.4.0"}
@@ -36,4 +36,4 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/jsthomas/tidy-email.git"
+dev-repo: "git+https://github.com/jsthomas/tidy_email.git"

--- a/tidy_email_smtp.opam
+++ b/tidy_email_smtp.opam
@@ -6,8 +6,8 @@ description: ""
 maintainer: ["jsthomas@protonmail.com"]
 authors: ["Joe Thomas"]
 license: "MIT"
-homepage: "https://github.com/jsthomas/tidy-email"
-bug-reports: "https://github.com/jsthomas/tidy-email/issues"
+homepage: "https://github.com/jsthomas/tidy_email"
+bug-reports: "https://github.com/jsthomas/tidy_email/issues"
 depends: [
   "bisect_ppx" {dev & >= "2.5.0"}
   "alcotest-lwt" {dev & >= "1.4.0"}
@@ -33,4 +33,4 @@ build: [
     "@doc" {with-doc}
   ]
 ]
-dev-repo: "git+https://github.com/jsthomas/tidy-email.git"
+dev-repo: "git+https://github.com/jsthomas/tidy_email.git"


### PR DESCRIPTION
Addresses #5. I've been using `tidy-email` in some places and `tidy_email` in others. It's much better to standardize on one name, `tidy_email` everywhere.

This doesn't appear to break links (github redirects to the new repo name), but it's much better to get everything consistent early on in any case.