### PR TITLE
Issue 9: Revise Sendgrid and Mailgun implementations for greater consistency and ease of use.

### DIFF
--- a/mailgun/src/tidy_email_mailgun.ml
+++ b/mailgun/src/tidy_email_mailgun.ml
@@ -1,16 +1,19 @@
+module Header = Cohttp.Header
+module Body = Cohttp_lwt.Body
+module Auth = Cohttp.Auth
+
 type config = {
   api_key : string;
   base_url : string;
 }
 
-type http_post_form =
+type http_post =
+  ?body:Cohttp_lwt.Body.t ->
   ?headers:Cohttp.Header.t ->
-  params:(string * string list) list ->
   Uri.t ->
   (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
 
-let client_send (post_form : http_post_form) (conf : config)
-    (e : Tidy_email.Email.t) =
+let client_send (post : http_post) (conf : config) (e : Tidy_email.Email.t) =
   let param =
     match e.body with
     | Text t -> [("text", [t])]
@@ -21,13 +24,20 @@ let client_send (post_form : http_post_form) (conf : config)
     @ param in
   let cred = `Basic ("api", conf.api_key) in
   let uri = conf.base_url ^ "/messages" |> Uri.of_string in
-  let headers = Cohttp.Header.add_authorization (Cohttp.Header.init ()) cred in
-  let%lwt response, body = post_form uri ~params ~headers in
-  let%lwt body_content = Cohttp_lwt.Body.to_string body in
+  let headers =
+    Cohttp.Header.of_list
+      [
+        ("content-type", "application/x-www-form-urlencoded");
+        ("authorization", Auth.string_of_credential cred);
+      ] in
+  let body = Body.of_string (Uri.encoded_of_query params) in
+  let%lwt response, resp_body = post ~headers ~body uri in
+  let%lwt body_content = Cohttp_lwt.Body.to_string resp_body in
   match Cohttp.Response.status response with
   | `OK -> Lwt.return_ok ()
   | _ -> Lwt.return_error body_content
 
 let send =
   client_send
-    (Cohttp_lwt_unix.Client.post_form ~ctx:Cohttp_lwt_unix.Net.default_ctx)
+    (Cohttp_lwt_unix.Client.post ~ctx:Cohttp_lwt_unix.Net.default_ctx
+       ~chunked:false)

--- a/mailgun/src/tidy_email_mailgun.ml
+++ b/mailgun/src/tidy_email_mailgun.ml
@@ -1,17 +1,21 @@
-module Header = Cohttp.Header
-module Body = Cohttp_lwt.Body
 module Auth = Cohttp.Auth
+module Body = Cohttp_lwt.Body
+module Header = Cohttp.Header
+module Response = Cohttp.Response
+
 
 type config = {
   api_key : string;
   base_url : string;
 }
 
+
 type http_post =
-  ?body:Cohttp_lwt.Body.t ->
-  ?headers:Cohttp.Header.t ->
+  ?body:Body.t ->
+  ?headers:Header.t ->
   Uri.t ->
-  (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
+  (Response.t * Body.t) Lwt.t
+
 
 let client_send (post : http_post) (conf : config) (e : Tidy_email.Email.t) =
   let param =
@@ -25,17 +29,18 @@ let client_send (post : http_post) (conf : config) (e : Tidy_email.Email.t) =
   let cred = `Basic ("api", conf.api_key) in
   let uri = conf.base_url ^ "/messages" |> Uri.of_string in
   let headers =
-    Cohttp.Header.of_list
+    Header.of_list
       [
         ("content-type", "application/x-www-form-urlencoded");
         ("authorization", Auth.string_of_credential cred);
       ] in
   let body = Body.of_string (Uri.encoded_of_query params) in
   let%lwt response, resp_body = post ~headers ~body uri in
-  let%lwt body_content = Cohttp_lwt.Body.to_string resp_body in
-  match Cohttp.Response.status response with
+  let%lwt body_content = Body.to_string resp_body in
+  match Response.status response with
   | `OK -> Lwt.return_ok ()
   | _ -> Lwt.return_error body_content
+
 
 let send =
   client_send

--- a/mailgun/src/tidy_email_mailgun.mli
+++ b/mailgun/src/tidy_email_mailgun.mli
@@ -3,20 +3,23 @@ type config = {
   base_url : string;  (** e.g. https://api.mailgun.net/v3/<your domain> *)
 }
 
-type http_post_form =
-  ?headers:Cohttp.Header.t ->
-  params:(string * string list) list ->
-  Uri.t ->
-  (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
-
-val client_send :
-  http_post_form -> config -> Tidy_email.Email.t -> (unit, string) Lwt_result.t
-(** This send function allows the caller to customize the HTTP request
-   (a form post) made to Mailgun, by providing their own HTTP
-   client as the first argument. *)
 
 val send : config -> Tidy_email.Email.t -> (unit, string) Lwt_result.t
 (** This is the function most users should utilize for sending email.
 
    If the underlying request to Mailgun's API is unsuccessful, the
    response body is provided in the result.  *)
+
+
+type http_post_form =
+  ?headers:Cohttp.Header.t ->
+  params:(string * string list) list ->
+  Uri.t ->
+  (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
+
+
+val client_send :
+  http_post_form -> config -> Tidy_email.Email.t -> (unit, string) Lwt_result.t
+(** This send function allows the caller to customize the HTTP request
+   (a form post) made to Mailgun, by providing their own HTTP
+   client as the first argument. *)

--- a/mailgun/src/tidy_email_mailgun.mli
+++ b/mailgun/src/tidy_email_mailgun.mli
@@ -3,23 +3,20 @@ type config = {
   base_url : string;  (** e.g. https://api.mailgun.net/v3/<your domain> *)
 }
 
-
 val send : config -> Tidy_email.Email.t -> (unit, string) Lwt_result.t
 (** This is the function most users should utilize for sending email.
 
    If the underlying request to Mailgun's API is unsuccessful, the
    response body is provided in the result.  *)
 
-
-type http_post_form =
+type http_post =
+  ?body:Cohttp_lwt.Body.t ->
   ?headers:Cohttp.Header.t ->
-  params:(string * string list) list ->
   Uri.t ->
   (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
 
-
 val client_send :
-  http_post_form -> config -> Tidy_email.Email.t -> (unit, string) Lwt_result.t
+  http_post -> config -> Tidy_email.Email.t -> (unit, string) Lwt_result.t
 (** This send function allows the caller to customize the HTTP request
    (a form post) made to Mailgun, by providing their own HTTP
    client as the first argument. *)

--- a/sendgrid/src/tidy_email_sendgrid.mli
+++ b/sendgrid/src/tidy_email_sendgrid.mli
@@ -4,6 +4,13 @@ type config = {
 }
 
 
+val send : config -> Tidy_email.Email.t -> (unit, string) Lwt_result.t
+(** This is the function most users should utilize for sending email.
+
+   If the underlying request to Sendgrid's API is unsuccessful, the
+   response body is provided in the result. *)
+
+
 type http_post =
   ?body:Cohttp_lwt.Body.t ->
   ?headers:Cohttp.Header.t ->
@@ -18,10 +25,3 @@ val client_send :
 (** This send function allows the caller to customize the HTTP request
    (a form post) made to Sendgrid by providing their own HTTP
    client as the first argument. *)
-
-
-val send : config -> Tidy_email.Email.t -> (unit, string) Lwt_result.t
-(** This is the function most users should utilize for sending email.
-
-   If the underlying request to Sendgrid's API is unsuccessful, the
-   response body is provided in the result. *)


### PR DESCRIPTION
This change addresses #9. The first part is simple: `config` and `send` functions now appear first in the `.mli` files for Sendgrid and Mailgun, since these are the main declarations users will need.

The second part refactors Mailgun's implementation so that `client_send` has the same signature as the one in Sendgrid. Previously, Mailgun used Cohttp's `post_form` to send data to the Mailgun's REST API. By recognizing that Cohttp implements `post_form` in terms of `post`, we can implement both modules in terms of `post` and make the two modules interfaces consistent.