### PR TITLE
Add Mailgun, Sendgrid, and SMTP integration tests via Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,3 +26,11 @@ jobs:
 
     - run: opam install --yes --deps-only --with-test .
     - run: opam exec -- dune runtest
+
+    - name: Run Mailgun integration test.
+      run: opam exec -- dune exec mailgun/example/send.exe ${{SENDER}} ${{RECEIVER}}
+      env:
+        SENDER: ${{secrets.MAILGUN_SEND_ADDRESS}}
+        RECEIVER: ${{secrets.INTEGRATION_TEST_RECEIVE_ADDRESS}}
+        MAILGUN_API_KEY: ${{secrets.MAILGUN_API_KEY}}
+        MAILGUN_BASE_URL: "https://api.mailgun.net/v3/${{secrets.MAILGUN_DOMAIN}}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     - run: opam exec -- dune runtest
 
     - name: Run Mailgun integration test.
-      run: opam exec -- dune exec mailgun/example/send.exe ${{SENDER}} ${{RECEIVER}}
+      run: opam exec -- dune exec mailgun/example/send.exe $SENDER $RECEIVER
       env:
         SENDER: ${{secrets.MAILGUN_SEND_ADDRESS}}
         RECEIVER: ${{secrets.INTEGRATION_TEST_RECEIVE_ADDRESS}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,11 @@ jobs:
       with:
         ocaml-compiler: ${{matrix.ocaml}}
 
-    - run: opam install --yes --deps-only --with-test .
-    - run: opam exec -- dune runtest
+    - name: Test OPAM install.
+      run: opam install --yes --deps-only --with-test .
+
+    - name: Run unit tests.
+      run: opam exec -- dune runtest
 
     - name: Run Mailgun integration test.
       run: opam exec -- dune exec mailgun/example/send.exe $SENDER $RECEIVER
@@ -34,3 +37,20 @@ jobs:
         RECEIVER: ${{secrets.INTEGRATION_TEST_RECEIVE_ADDRESS}}
         MAILGUN_API_KEY: ${{secrets.MAILGUN_API_KEY}}
         MAILGUN_BASE_URL: "https://api.mailgun.net/v3/${{secrets.MAILGUN_DOMAIN}}"
+
+    - name: Run Sendgrid integration test.
+      run: opam exec -- dune exec sendgrid/example/send.exe $SENDER $RECEIVER
+      env:
+        SENDER: ${{secrets.SENDGRID_SEND_ADDRESS}}
+        RECEIVER: ${{secrets.INTEGRATION_TEST_RECEIVE_ADDRESS}}
+        SENDGRID_API_KEY: ${{secrets.SENDGRID_API_KEY}}
+        SENDGRID_BASE_URL: "https://api.sendgrid.com/v3/mail/send"
+
+    - name: Run SMTP integration test.
+      run: opam exec -- dune exec smtp/example/send.exe $SENDER $RECEIVER
+      env:
+        SENDER: ${{secrets.MAILGUN_SEND_ADDRESS}}
+        RECEIVER: ${{secrets.INTEGRATION_TEST_RECEIVE_ADDRESS}}
+        SMTP_USERNAME: ${{secrets.SMTP_USERNAME}}
+        SMTP_PASSWORD: ${{secrets.SMTP_PASSWORD}}
+        SMTP_HOSTNAME: "smtp.mailgun.org"

--- a/sendgrid/example/send.ml
+++ b/sendgrid/example/send.ml
@@ -25,11 +25,15 @@ let send use_html sender recipient =
   let email = Email.make ~sender ~recipient ~subject ~body in
   Printf.printf "Starting email send.\n";
   let%lwt result = Sendgrid.send config email in
-  let _ =
+  let exit_code =
     match result with
-    | Ok _ -> Printf.printf "Send succeeded.\n"
-    | Error _ -> Printf.printf "Send failed.\n" in
-  Lwt.return_unit
+    | Ok _ ->
+      Printf.printf "Send succeeded.\n";
+      0
+    | Error _ ->
+      Printf.printf "Send failed.\n";
+      1 in
+  Lwt.return exit_code
 
 let run kind sender recipient = Lwt_main.run @@ send kind sender recipient
 
@@ -53,4 +57,9 @@ let () =
   let doc = "Send a message from recipient to sender." in
   let info = Term.info "text_email" ~doc in
   Printf.printf "Starting.\n";
-  Term.exit @@ Term.eval (run_t, info)
+  let result = Term.eval (run_t, info) in
+  let result' = match result with
+    | `Ok 1 -> `Error `Exn
+    | _ -> result
+  in
+  Term.exit @@ result'


### PR DESCRIPTION
This change addresses #6. It adds steps to the CI system to trigger the integration tests for each of the three integrations currently in the repo. This means that a maintainer-controlled email account will get test emails via Mailgun, Sendgrid, and (Mailgun) SMTP on each successful CI run. Due to how Github Secrets works, these steps will not run on external pull requests (otherwise, a malicious user could open a PR with a change that leaks secrets).