### PR TITLE
Refactor to make it easier to change email backends.

### DIFF
--- a/mailgun/example/send.ml
+++ b/mailgun/example/send.ml
@@ -15,16 +15,15 @@ let html_body =
 let text_body = Email.Text "This is what a plain text email body looks like."
 
 let send use_html sender recipient =
-  let config : Mailgun.config =
-    {
-      api_key = Sys.getenv "MAILGUN_API_KEY";
-      base_url = Sys.getenv "MAILGUN_BASE_URL";
-    } in
   let subject = "Test message from tidy_email via Mailgun." in
   let body = if use_html then html_body else text_body in
   let email = Email.make ~sender ~recipient ~subject ~body in
+  let send = Mailgun.backend {
+      api_key = Sys.getenv "MAILGUN_API_KEY";
+      base_url = Sys.getenv "MAILGUN_BASE_URL";
+    } in
   Printf.printf "Starting email send.\n";
-  let%lwt result = Mailgun.send config email in
+  let%lwt result = send email in
   let exit_code =
     match result with
     | Ok _ ->

--- a/mailgun/src/tidy_email_mailgun.mli
+++ b/mailgun/src/tidy_email_mailgun.mli
@@ -3,20 +3,10 @@ type config = {
   base_url : string;  (** e.g. https://api.mailgun.net/v3/<your domain> *)
 }
 
-val send : config -> Tidy_email.Email.t -> (unit, string) Lwt_result.t
-(** This is the function most users should utilize for sending email.
-
-   If the underlying request to Mailgun's API is unsuccessful, the
-   response body is provided in the result.  *)
-
 type http_post =
   ?body:Cohttp_lwt.Body.t ->
   ?headers:Cohttp.Header.t ->
   Uri.t ->
   (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
 
-val client_send :
-  http_post -> config -> Tidy_email.Email.t -> (unit, string) Lwt_result.t
-(** This send function allows the caller to customize the HTTP request
-   (a form post) made to Mailgun, by providing their own HTTP
-   client as the first argument. *)
+val backend : ?client:http_post -> config -> Tidy_email.Email.t -> (unit, string) Lwt_result.t

--- a/mailgun/src/tidy_email_mailgun.mli
+++ b/mailgun/src/tidy_email_mailgun.mli
@@ -10,3 +10,8 @@ type http_post =
   (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
 
 val backend : ?client:http_post -> config -> Tidy_email.Email.t -> (unit, string) Lwt_result.t
+(** If the underlying request to Sendgrid's API is unsuccessful, the
+   response body is provided in the result.
+
+   client allows the user to customize how their HTTP post is
+   performed. Most users will want to use the default. *)

--- a/mailgun/test/test_send.ml
+++ b/mailgun/test/test_send.ml
@@ -95,9 +95,9 @@ let test_bad_credentials _ () =
   (* When Mailgun replies with a 401 Unauthorized due to bad
      credentials, the send fails with an error. *)
   let client = post text_body `Unauthorized "Forbidden" in
-  let sender = Mg.client_send client in
+  let send = Mg.backend ~client config in
   email text_body
-  |> sender config
+  |> send
   >|= check_result "An error is produced." (Error "Forbidden")
 
 let bad_data_response =
@@ -111,9 +111,9 @@ let test_bad_data _ () =
   (* When Mailgun replies with a 400 Bad Request, the function call
      converts the response to an error. *)
   let client = post text_body `Bad_request bad_data_response in
-  let sender = Mg.client_send client in
+  let send = Mg.backend ~client config in
   email text_body
-  |> sender config
+  |> send
   >|= check_result "An error is produced." (Error bad_data_response)
 
 let ok_response =
@@ -128,8 +128,8 @@ let test_success body =
   let test _ () =
     (* The backend produces an ok when Mailgun replies with a 200 OK.*)
     let client = post body `OK ok_response in
-    let sender = Mg.client_send client in
-    email body |> sender config >|= check_result "An ok is produced." (Ok ())
+    let send = Mg.backend ~client config in
+    email body |> send >|= check_result "An ok is produced." (Ok ())
   in
   test
 

--- a/sendgrid/example/send.ml
+++ b/sendgrid/example/send.ml
@@ -15,7 +15,7 @@ let html_body =
 let text_body = Email.Text "This is what a plain text email body looks like."
 
 let send use_html sender recipient =
-  let config : Sendgrid.config =
+  let send = Sendgrid.backend
     {
       api_key = Sys.getenv "SENDGRID_API_KEY";
       base_url = Sys.getenv "SENDGRID_BASE_URL";
@@ -24,7 +24,7 @@ let send use_html sender recipient =
   let body = if use_html then html_body else text_body in
   let email = Email.make ~sender ~recipient ~subject ~body in
   Printf.printf "Starting email send.\n";
-  let%lwt result = Sendgrid.send config email in
+  let%lwt result = send email in
   let exit_code =
     match result with
     | Ok _ ->

--- a/sendgrid/src/tidy_email_sendgrid.mli
+++ b/sendgrid/src/tidy_email_sendgrid.mli
@@ -1,14 +1,7 @@
 type config = {
-  api_key : string;  (** e.g. https://api.sendgrid.com/v3/mail/send *)
-  base_url : string;
-      (** An alphanumeric string found on the Sendgrid console. *)
+  api_key : string;  (** An alphanumeric string found on the Sendgrid console. *)
+  base_url : string; (** e.g. https://api.sendgrid.com/v3/mail/send *)
 }
-
-val send : config -> Tidy_email.Email.t -> (unit, string) Lwt_result.t
-(** This is the function most users should utilize for sending email.
-
-   If the underlying request to Sendgrid's API is unsuccessful, the
-   response body is provided in the result. *)
 
 type http_post =
   ?body:Cohttp_lwt.Body.t ->
@@ -16,8 +9,10 @@ type http_post =
   Uri.t ->
   (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
 
-val client_send :
-  http_post -> config -> Tidy_email.Email.t -> (unit, string) Lwt_result.t
-(** This send function allows the caller to customize the HTTP request
-   (a form post) made to Sendgrid by providing their own HTTP
-   client as the first argument. *)
+val backend :
+  ?client:http_post -> config -> Tidy_email.Email.t -> (unit, string) Lwt_result.t
+(** If the underlying request to Sendgrid's API is unsuccessful, the
+   response body is provided in the result.
+
+   client allows the user to customize how their HTTP post is
+   performed. Most users will want to use the default. *)

--- a/sendgrid/test/test_send.ml
+++ b/sendgrid/test/test_send.ml
@@ -128,9 +128,8 @@ let test_bad_credentials _ () =
      credentials, the send fails with an error. *)
   let client =
     post text_body `Unauthorized (Body.of_string bad_credentials_response) in
-  let sender = Sg.client_send client in
-  email text_body
-  |> sender config
+  let send = Sg.backend ~client config in
+  text_body |> email |> send
   >|= check_result "An error is produced." (Error bad_credentials_response)
 
 let bad_data_response =
@@ -154,17 +153,16 @@ let test_bad_data _ () =
      but if Sendgrid changed their schema this is the error we would
      expect to see. *)
   let client = post text_body `Bad_request (Body.of_string bad_data_response) in
-  let sender = Sg.client_send client in
-  email text_body
-  |> sender config
+  let send = Sg.backend ~client config in
+  text_body |> email |> send
   >|= check_result "An error is produced." (Error bad_data_response)
 
 let test_success body =
   let test _ () =
     (* The backend produces an ok when Sendgrid replies with a 202 Accepted.*)
     let client = post body `Accepted Body.empty in
-    let sender = Sg.client_send client in
-    email body |> sender config >|= check_result "An ok is produced." (Ok ())
+    let send = Sg.backend ~client config in
+    body |> email |> send >|= check_result "An ok is produced." (Ok ())
   in
   test
 

--- a/smtp/example/send.ml
+++ b/smtp/example/send.ml
@@ -15,7 +15,7 @@ let html_body =
 let text_body = Email.Text "This is what a plain text email body looks like."
 
 let send use_html sender recipient =
-  let config =
+  let send = Smtp.backend @@
     Letters.Config.make
       ~username:(Sys.getenv "SMTP_USERNAME")
       ~password:(Sys.getenv "SMTP_PASSWORD")
@@ -26,7 +26,7 @@ let send use_html sender recipient =
     Email.make ~sender ~recipient
       ~subject:"Test message from tidy_email via SMTP" ~body in
   Printf.printf "Starting email send.\n";
-  let%lwt result = Smtp.send config email in
+  let%lwt result = send email in
   let exit_code =
     match result with
     | Ok _ ->

--- a/smtp/src/tidy_email_smtp.ml
+++ b/smtp/src/tidy_email_smtp.ml
@@ -1,6 +1,6 @@
 module Config = Letters.Config
 
-let send config (e : Tidy_email.Email.t) =
+let backend config (e : Tidy_email.Email.t) =
   let sender = e.sender in
   let recipients = List.map (fun r -> Letters.To r) e.recipients in
   let subject = e.subject in

--- a/smtp/src/tidy_email_smtp.mli
+++ b/smtp/src/tidy_email_smtp.mli
@@ -5,7 +5,7 @@ module Config = Letters.Config
 (** The primary data you will need to configure an SMTP connection are
    hostname, username, and password strings. *)
 
-val send : Config.t -> Tidy_email.Email.t -> (unit, string) Lwt_result.t
+val backend : Config.t -> Tidy_email.Email.t -> (unit, string) Lwt_result.t
 (** Send the input email via SMTP.
 
    If the underlying request to the SMTP server is unsuccessful, the


### PR DESCRIPTION
This change partially addresses #8 and eliminates the confusing and unnecessary `client_send` function from the API. 

The main idea is to use currying more effectively. Each email integration defines a function called `backend` that consumes one or more integration specific arguments, and produces a function of type:
```Tidy_email.Email.t -> (unit, string) Lwt_result.t```

Users will invoke `backend` with their email provider credentials to get an email-sending function, like this:
```
  let send = Tidy_email_mailgun.backend {
      api_key = Sys.getenv "MAILGUN_API_KEY";
      base_url = Sys.getenv "MAILGUN_BASE_URL";
    }
```
and then write the rest of their code in terms of `send`. If they later decide to use a different email provider, they just need to modify the definition of `send`.

It would be nice to get rid of the `Tidy_email.Email.t` entirely, and replace it with the email type in Letters; I'm planning to look at that in a separate PR.